### PR TITLE
Implement dynamic schedule and admin settings

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -191,6 +191,15 @@ tbody tr:hover {
     min-height: 20px;
 }
 
+.success-message {
+    color: #2ecc71;
+    margin-top: 10px;
+    margin-bottom: 15px;
+    text-align: center;
+    font-size: 0.9rem;
+    min-height: 20px;
+}
+
 /* 반응형 스타일 */
 @media (max-width: 768px) {
     .admin-header {

--- a/admin.html
+++ b/admin.html
@@ -58,6 +58,21 @@
                     <p>선택한 날짜에 예약이 없습니다.</p>
                 </div>
             </div>
+            <div class="admin-panel">
+                <h2>관리자 계정 관리</h2>
+                <form id="account-form">
+                    <div class="form-group">
+                        <label for="new-username">아이디</label>
+                        <input type="text" id="new-username" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="new-password">비밀번호</label>
+                        <input type="password" id="new-password" required>
+                    </div>
+                    <div id="account-message" class="success-message"></div>
+                    <button type="submit" class="btn submit-btn">저장</button>
+                </form>
+            </div>
         </div>
     </main>
 

--- a/admin.js
+++ b/admin.js
@@ -18,6 +18,24 @@ document.addEventListener('DOMContentLoaded', function() {
     const detailModal = document.getElementById('reservation-detail-modal');
     const closeDetailBtn = document.getElementById('close-detail');
     const deleteReservationBtn = document.getElementById('delete-reservation');
+
+    // 계정 관리 요소
+    const accountForm = document.getElementById('account-form');
+    const newUsernameInput = document.getElementById('new-username');
+    const newPasswordInput = document.getElementById('new-password');
+    const accountMsg = document.getElementById('account-message');
+
+    function getAdminAccount() {
+        const stored = localStorage.getItem('admin_account');
+        if (stored) {
+            try { return JSON.parse(stored); } catch (e) {}
+        }
+        return { username: 'admin', password: 'password' };
+    }
+
+    function saveAdminAccount(username, password) {
+        localStorage.setItem('admin_account', JSON.stringify({ username, password }));
+    }
     
     // 선택된 예약 ID를 저장하는 변수
     let selectedReservationId = null;
@@ -264,6 +282,26 @@ document.addEventListener('DOMContentLoaded', function() {
         window.location.href = 'login.html';
     }
     
+    // 계정 관리 폼 처리
+    if (accountForm) {
+        const current = getAdminAccount();
+        newUsernameInput.value = current.username;
+        newPasswordInput.value = current.password;
+
+        accountForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            const u = newUsernameInput.value.trim();
+            const p = newPasswordInput.value;
+            if (!u || !p) {
+                accountMsg.textContent = '아이디와 비밀번호를 입력하세요.';
+                return;
+            }
+            saveAdminAccount(u, p);
+            accountMsg.textContent = '저장되었습니다.';
+            setTimeout(() => { accountMsg.textContent = ''; }, 2000);
+        });
+    }
+
     // 초기 데이터 로드
     displayReservations(viewDateInput.value);
 }); 

--- a/index.html
+++ b/index.html
@@ -143,19 +143,6 @@
                     <label for="time">예약 시간</label>
                     <select id="time" name="time" required>
                         <option value="">시간 선택</option>
-                        <option value="09:00">09:00</option>
-                        <option value="09:30">09:30</option>
-                        <option value="10:00">10:00</option>
-                        <option value="10:30">10:30</option>
-                        <option value="11:00">11:00</option>
-                        <option value="11:30">11:30</option>
-                        <option value="14:00">14:00</option>
-                        <option value="14:30">14:30</option>
-                        <option value="15:00">15:00</option>
-                        <option value="15:30">15:30</option>
-                        <option value="16:00">16:00</option>
-                        <option value="16:30">16:30</option>
-                        <option value="17:00">17:00</option>
                     </select>
                 </div>
                 <div class="form-group">

--- a/login.js
+++ b/login.js
@@ -8,9 +8,17 @@ document.addEventListener('DOMContentLoaded', function() {
     const loginError = document.getElementById('login-error');
     const togglePasswordBtn = document.querySelector('.toggle-password');
     
-    // 관리자 계정 정보 (실제로는 서버 측에서 처리해야 함)
-    const ADMIN_USERNAME = 'josm0106';
-    const ADMIN_PASSWORD = 'whtpaud';
+    // 기본 관리자 계정 (로컬 스토리지에 저장)
+    const DEFAULT_ADMIN = { username: 'admin', password: 'password' };
+
+    function getAdminAccount() {
+        const stored = localStorage.getItem('admin_account');
+        if (stored) {
+            try { return JSON.parse(stored); } catch (e) {}
+        }
+        localStorage.setItem('admin_account', JSON.stringify(DEFAULT_ADMIN));
+        return DEFAULT_ADMIN;
+    }
     
     // 저장된 로그인 정보 불러오기
     loadSavedCredentials();
@@ -41,8 +49,9 @@ document.addEventListener('DOMContentLoaded', function() {
             return;
         }
         
-        // 인증 확인 (실제로는 서버 측에서 처리해야 함)
-        if (username === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
+        // 저장된 관리자 계정 확인
+        const admin = getAdminAccount();
+        if (username === admin.username && password === admin.password) {
             // 인증 성공
             loginError.textContent = '';
             

--- a/script.js
+++ b/script.js
@@ -43,6 +43,33 @@ function generateId() {
     return Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
 }
 
+// 시간 옵션 생성
+function generateTimeOptions() {
+    const timeSelect = document.getElementById('time');
+    if (!timeSelect) return;
+
+    // 기존 옵션 제거 (placeholder 제외)
+    while (timeSelect.options.length > 1) {
+        timeSelect.remove(1);
+    }
+
+    const startMorning = 9 * 60; // 09:00 in minutes
+    const lunchStart = 12 * 60; // 12:00
+    const lunchEnd = 14 * 60;   // 14:00
+    const endDay = 18 * 60;     // 18:00
+
+    for (let minutes = startMorning; minutes < endDay; minutes += 15) {
+        if (minutes >= lunchStart && minutes < lunchEnd) continue; // 점심시간 제외
+        const h = String(Math.floor(minutes / 60)).padStart(2, '0');
+        const m = String(minutes % 60).padStart(2, '0');
+        const value = `${h}:${m}`;
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = value;
+        timeSelect.appendChild(option);
+    }
+}
+
 // 모든 예약 가져오기
 function getAllReservations() {
     const reservationsJson = localStorage.getItem('reservations');
@@ -94,7 +121,10 @@ function updateAvailableTimeSlots(selectedDate) {
 // 예약 버튼 클릭 시 모달 열기
 reservationBtn.addEventListener('click', function() {
     openModal(reservationModal);
-    
+
+    // 시간 옵션 동적 생성
+    generateTimeOptions();
+
     // 날짜 필드에 오늘 날짜 이후만 선택 가능하도록 설정
     const dateInput = document.getElementById('date');
     const today = new Date();
@@ -211,6 +241,7 @@ function closeModal(modal) {
 
 // 페이지 로드 애니메이션
 document.addEventListener('DOMContentLoaded', function() {
+    generateTimeOptions();
     const heroContent = document.querySelector('.hero-content');
     const heroImage = document.querySelector('.hero-image');
     const infoCards = document.querySelectorAll('.info-card');


### PR DESCRIPTION
## Summary
- add localstorage-based admin credential management
- allow editing admin account on admin page
- generate 15 minute timeslots dynamically skipping lunch
- adjust scripts to populate timeslots and validate reservations

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68420eae62048331a9777d3129aef35c